### PR TITLE
fix highlighting for members when omitting service curly braces

### DIFF
--- a/syntaxes/fsd.tmLanguage.json
+++ b/syntaxes/fsd.tmLanguage.json
@@ -77,7 +77,7 @@
 		"service-declaration": {
 			"name": "meta.service.fsd",
 			"begin": "(?=\\bservice\\b)",
-			"end": "(?<=\\})",
+      "end": "(?<=\\})|(?=^#\\s+)",
 			"patterns": [
 				{
 					"match": "\\b(service)\\s+([a-zA-Z_][a-zA-Z_0-9]*)\\b",
@@ -91,13 +91,13 @@
 					}
 				},
 				{
-					"begin": "\\{",
+          "begin": "(\\{)|(;)",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.block.ts"
 						}
 					},
-					"end": "\\}",
+          "end": "(\\})|(?=^#\\s+)",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.block.ts"

--- a/syntaxes/fsd.tmLanguage.json
+++ b/syntaxes/fsd.tmLanguage.json
@@ -77,7 +77,7 @@
 		"service-declaration": {
 			"name": "meta.service.fsd",
 			"begin": "(?=\\bservice\\b)",
-      "end": "(?<=\\})|(?=^#\\s+)",
+			"end": "(?<=\\})|(?=^#\\s+)",
 			"patterns": [
 				{
 					"match": "\\b(service)\\s+([a-zA-Z_][a-zA-Z_0-9]*)\\b",
@@ -91,13 +91,13 @@
 					}
 				},
 				{
-          "begin": "(\\{)|(;)",
+					"begin": "(\\{)|(;)",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.block.ts"
 						}
 					},
-          "end": "(\\})|(?=^#\\s+)",
+					"end": "(\\})|(?=^#\\s+)",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.block.ts"


### PR DESCRIPTION
addresses https://github.com/FacilityApi/FacilityVSCode/issues/3

It looks as though there is still an issue with the end pattern because the markdown injection is not working for services without curly braces.

I am not very familiar with TM grammars.